### PR TITLE
Fix regex in Google.pm

### DIFF
--- a/Whatbot/lib/Whatbot/Command/Google.pm
+++ b/Whatbot/lib/Whatbot/Command/Google.pm
@@ -58,8 +58,8 @@ sub _search {
 	my $url = sprintf( 'http://www.google.com/search?q=%s', uri_escape($query) );
 	my $response = $self->ua->get($url);
 	if ( $response->is_success ) {
-		my @results = ( $response->decoded_content =~ /(<h3 class="r"><a href="\/url\?q=http[^"]+">.+?<\/a>.*?<span class="st">.+?<\/span>)/g );
-		if ( @results and $results[0] =~ /<a href="\/url\?q=(http[^"]+)">(.+?)<\/a>.*?<span class="st">(.+?)<\/span/ ) {
+		my @results = ( $response->decoded_content =~ /(<h3 class="r"><a href="\/url\?q=http[^"]+">.+?<\/a>.*?<span class="st">.+?<\/span>)/sg );
+		if ( @results and $results[0] =~ /<a href="\/url\?q=(http[^"]+)">(.+?)<\/a>.*?<span class="st">(.+?)<\/span/s ) {
 			my ( $url, $title, $description ) = ( decode_entities($1), decode_entities($2), decode_entities($3) );
 			$title = Whatbot::Utility::html_strip($title);
 			$description = Whatbot::Utility::html_strip($description);


### PR DESCRIPTION
Google.pm won't work (and thus will fail its unit tests and fail to install) unless you have the /s flag on the regex parsing google's result.