### PR TITLE
possible fix for paste when hipchat enabled.

### DIFF
--- a/Whatbot-Command-Paste/lib/Whatbot/Command/Paste.pm
+++ b/Whatbot-Command-Paste/lib/Whatbot/Command/Paste.pm
@@ -53,9 +53,10 @@ sub paste_form {
 	return unless ( $self->check_access($req) );
 
 	my @channels;
-	foreach my $io ( values %{ $self->ios } ) {
+	foreach my $interface ( keys %{ $self->ios } ) {
+		my $io = $self->ios->{$interface};
 		next unless ( $io->can('channels') );
-		push( @channels, ( map { $_->{'name'} } @{ $io->channels } ) );
+		push( @channels, ( map { ref($_) ? $_->{name} : sprintf('%s:%s@%s',$interface,$_,$io->{my_config}->{conference_server}) } @{ $io->channels } ) );
 	}
 
 	my %state = (


### PR DESCRIPTION
Possible fix for issue #32 

This allowed paste to work with HipChat and notify the room.  Not sure if this will break a jabber integration but it works with HipChat .  Only downside is that the channel dropdown is really long.

Thanks,
Chuck
