### PR TITLE
Add support for the Dark Sky API in Weather

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -30,6 +30,7 @@ requires       'DBD::SQLite'                    => 0;
 requires       'Devel::StackTrace'              => 0;
 requires       'Digest::SHA1'                   => 0;
 requires       'EV'                             => 0;
+requires       'Geo::Coder::OSM'                => 0;
 requires       'HTTP::Cookies'                  => 0;
 requires       'HTML::Entities'                 => 0;
 requires       'HTTP::Request'                  => 0;

--- a/lib/Whatbot/Command/Weather/Darksky.pm
+++ b/lib/Whatbot/Command/Weather/Darksky.pm
@@ -1,0 +1,141 @@
+###########################################################################
+# Whatbot/Command/Weather/Darksky.pm
+###########################################################################
+# Retrieve weather from the Darksky API
+###########################################################################
+# the whatbot project - http://www.whatbot.org
+###########################################################################
+
+use Moops;
+
+class Whatbot::Command::Weather::Darksky with Whatbot::Command::Weather::SourceRole {
+    use DateTime;
+    use Geo::Coder::OSM;
+    use JSON::XS;
+    use Whatbot::Command::Weather::Current;
+    use Whatbot::Command::Weather::Forecast;
+
+    has 'api_key' => (
+        'is'       => 'rw',
+        'isa'      => 'Str',
+        'required' => 1,
+    );
+
+    method _get_uri( Str $command, Str $query ) {
+        return sprintf(
+            'https://api.darksky.net/%s/%s/%s?units=us',
+            $command,
+            $self->api_key,
+            $query
+        );
+    }
+
+    method get_current( Str $location ) {
+        my $resolved = $self->_resolve_location_string($location);
+        my $query = $self->_location($resolved->{'coordinates'});
+
+        my $json = $self->_fetch_and_decode(
+            $self->_get_uri( 'forecast', $query ) . '&exclude=minutely,hourly,daily'
+        );
+
+        if ( $json->{'currently'} ) {
+            my $current_obj = Whatbot::Command::Weather::Current->new({
+                'display_location' => $resolved->{'display'},
+                'conditions'       => $json->{'currently'}->{'summary'},
+                'temperature_f'    => $json->{'currently'}->{'temperature'},
+                'feels_like_f'     => $json->{'currently'}->{'apparentTemperature'},
+
+            });
+            if ($json->{'alerts'} and @{$json->{'alerts'}}) {
+                map {
+                    $current_obj->add_alert($_->{'title'});
+                } @{$json->{'alerts'}};
+            }
+            return $current_obj;
+        }
+        return;
+    }
+
+    method get_forecast( Str $location ) {
+        my $resolved = $self->_resolve_location_string($location);
+        my $query = $self->_location($resolved->{'coordinates'});
+
+        my $json = $self->_fetch_and_decode(
+            $self->_get_uri( 'forecast', $query ) . '&exclude=currently,minutely,hourly'
+        );
+        return unless ( $json and ref($json) and $json->{'daily'} );
+
+        my @days;
+        foreach my $forecast (@{$json->{'daily'}->{'data'}}[0..2]) {
+            my $dt = DateTime->from_epoch(
+                'epoch'     => $forecast->{'time'},
+                'time_zone' => $json->{'timezone'},
+            );
+            my $f = Whatbot::Command::Weather::Forecast->new({
+                'weekday'            => $dt->ymd(),
+                'high_temperature_f' => $forecast->{'temperatureHigh'},
+                'low_temperature_f'  => $forecast->{'temperatureLow'},
+                'conditions'         => $forecast->{'summary'},
+            });
+            push(@days, $f);
+        }
+
+        return \@days;
+    }
+
+    method _location( Str $location ) {
+        my $query;
+
+        if ( $location =~ /^(\-?[\d\.]+), ?(\-?[\d\.]+)$/ ) {
+            $query = "$1,$2";
+        } else {
+            die 'Unwilling to figure out what you meant by "' . $location . '"';
+        }
+
+        return $query;
+    }
+
+    method _resolve_location_string( Str $location ) {
+        if ( $location =~ /,/ or $location =~ /^\d+$/ ) {
+            my $osm = Geo::Coder::OSM->new();
+            my $resolved = $osm->geocode( location => $location );
+            if ($resolved and $resolved->{'lat'}) {
+                return {
+                    'coordinates' => join( ',', $resolved->{'lat'}, $resolved->{'lon'} ),
+                    'display'     => join( ', ',
+                        $resolved->{'address'}->{'city'},
+                        $resolved->{'address'}->{'state'},
+                        $resolved->{'address'}->{'country'}
+                    ),
+                };
+            }
+        }
+        
+        return {
+            'coordinates' => $location,
+            'display'     => $location,
+        };
+    }
+
+    method _fetch_and_decode( Str $url ) {
+        my $response = $self->ua->get($url);
+        my $content = $response->decoded_content;
+
+        return decode_json( $content );
+    }
+
+}
+
+1;
+
+=pod
+
+=head1 NAME
+
+Whatbot::Command::Weather::Darksky - Retrieve weather from the Dark Sky API
+
+=head1 LICENSE/COPYRIGHT
+
+Be excellent to each other and party on, dudes.
+
+=cut

--- a/lib/Whatbot/Command/Weather/Openweathermap.pm
+++ b/lib/Whatbot/Command/Weather/Openweathermap.pm
@@ -110,7 +110,7 @@ class Whatbot::Command::Weather::Openweathermap with Whatbot::Command::Weather::
 
 =head1 NAME
 
-Whatbot::Command::Weather::Wunderground - Retrieve weather from the Wunderground API
+Whatbot::Command::Weather::Openweathermap - Retrieve weather from the OpenWeatherMap API
 
 =head1 LICENSE/COPYRIGHT
 

--- a/t/command-weather-darksky.t
+++ b/t/command-weather-darksky.t
@@ -1,0 +1,77 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+use Whatbot::Test;
+
+unless ( $ENV{'WB_DARKSKY_API_KEY'} ) {
+    plan skip_all => 'Requires WB_DARKSKY_API_KEY environment variable to run live tests.';
+    done_testing();
+}
+
+use_ok( 'Whatbot::Command::Weather::Darksky', 'Load Module' );
+
+my $test = Whatbot::Test->new();
+$test->initialize_state();
+
+ok( my $darksky = Whatbot::Command::Weather::Darksky->new({
+    'api_key' => $ENV{'WB_DARKSKY_API_KEY'},
+}), 'new' );
+
+my $object = $darksky->get_current('43.653,-79.387');
+ok( $object, 'has a response' );
+is( ref($object), 'Whatbot::Command::Weather::Current', 'correct object type' );
+ok( $object->display_location, 'has display location' );
+is( $object->display_location, 'Toronto, Ontario, Canada', 'has correct display location' );
+ok( defined $object->temperature_f, 'has temperature' );
+ok( $object->to_string, 'to_string works' );
+
+$object = $darksky->get_current('fairfield, vt');
+ok( $object, 'has a response' );
+is( ref($object), 'Whatbot::Command::Weather::Current', 'correct object type' );
+ok( $object->display_location, 'has display location' );
+is( $object->display_location, 'Fairfield, Vermont, United States', 'has correct display location' );
+ok( defined $object->temperature_f, 'has temperature' );
+ok( $object->to_string, 'to_string works' );
+
+$object = $darksky->get_current('seattle, us');
+ok( $object, 'has a response' );
+is( ref($object), 'Whatbot::Command::Weather::Current', 'correct object type' );
+ok( $object->display_location, 'has display location' );
+is( $object->display_location, 'Seattle, Washington, United States of America', 'has correct display location' );
+ok( defined $object->temperature_f, 'has temperature' );
+ok( $object->to_string, 'to_string works' );
+
+$object = $darksky->get_current('toronto, ca');
+ok( $object, 'has a response' );
+is( ref($object), 'Whatbot::Command::Weather::Current', 'correct object type' );
+ok( $object->display_location, 'has display location' );
+is( $object->display_location, 'Toronto, Ontario, Canada', 'has correct display location' );
+ok( defined $object->temperature_f, 'has temperature' );
+ok( $object->to_string, 'to_string works' );
+
+throws_ok(
+    sub { $darksky->get_current('abcd') },
+    qr/^Unwilling to figure out what you meant by "abc/,
+    'get_current handles bad location'
+);
+
+$object = $darksky->get_forecast('43.653,-79.387');
+ok( $object, 'has a response' );
+is( ref($object), 'ARRAY', 'response is array' );
+my $first = $object->[0];
+is( ref($first), 'Whatbot::Command::Weather::Forecast', 'correct object type' );
+ok( $first->weekday,'has weekday' );
+ok( defined $first->high_temperature_f, 'has high temperature' );
+ok( defined $first->low_temperature_f, 'has low temperature' );
+ok( $first->to_string, 'to_string works' );
+
+throws_ok(
+    sub { $darksky->get_forecast('abcd') },
+    qr/^Unwilling to figure out what you meant by "abc/,
+    'get_forecast handles bad location'
+);
+
+done_testing();


### PR DESCRIPTION
After replacing Wunderground with OpenWeatherMap, @jmoses pointed out the existence of Dark Sky. This adds support for the Dark Sky API along side OpenWeatherMap for some additional options. The engine can be selected in the configuration, as long as an API key is provided. The data from the Dark Sky API is far more rich than OWM.